### PR TITLE
Avoid persisting do_resize in saved processors

### DIFF
--- a/training/train/train_grpo_timelens.py
+++ b/training/train/train_grpo_timelens.py
@@ -194,9 +194,11 @@ def train():
     if training_args.local_rank in (0, -1):
         print_trainable_parameters(model, training_args=training_args)
 
+    # `qwen_vl_utils` already resizes frames in the data pipeline, so keep
+    # `do_resize=False` at the processor call sites instead of persisting it
+    # into the saved processor defaults.
     processor = processor_cls.from_pretrained(
         model_args.model_name_or_path,
-        do_resize=False,
         padding_side="left",
         trust_remote_code=True,
     )

--- a/training/train/train_sft_timelens.py
+++ b/training/train/train_sft_timelens.py
@@ -207,8 +207,11 @@ def train():
     if training_args.local_rank in (0, -1):
         print_trainable_parameters(model, training_args=training_args)
 
+    # `qwen_vl_utils` already resizes frames in the data pipeline, so keep
+    # `do_resize=False` at the processor call sites instead of persisting it
+    # into the saved processor defaults.
     processor = processor_cls.from_pretrained(
-        model_args.model_name_or_path, do_resize=False, trust_remote_code=True
+        model_args.model_name_or_path, trust_remote_code=True
     )
 
     if training_args.bits in [4, 8]:


### PR DESCRIPTION
## What
- stop overriding `do_resize=False` when loading the processor in the SFT/GRPO training entrypoints
- keep `do_resize=False` only at the processor call sites that already consume `qwen_vl_utils`-resized inputs

## Why
Passing `do_resize=False` into `from_pretrained()` changes the saved processor defaults. When the checkpoint is later exported with `processing_class.save_pretrained(...)`, that runtime override is persisted into the Hub artifact and can break inference runtimes such as vLLM that rely on the saved processor configuration.